### PR TITLE
Fixed wotd query

### DIFF
--- a/bot/src/discord/schedule_helper.js
+++ b/bot/src/discord/schedule_helper.js
@@ -60,7 +60,7 @@ async function setTimer(monochrome, firstCall) {
       const dueSchedules = await WordScheduleModel.find({
         status: statusConstants.running,
         start: { $lte: now },
-        $or: [{ lastSent: null }, { $expr: { $lt: ['$lastSent', { $subtract: [now, '$frequency'] }] } }],
+        $or: [{ lastSent: null }, { $expr: { $lte: ['$lastSent', { $subtract: [now, '$frequency'] }] } }],
       });
 
       await Promise.all(dueSchedules.map(async (schedule, i) => {


### PR DESCRIPTION
Wotd was running later and later each day because 'lastSent' was 18:00 and it wasn't **lower than** 'now' minus 'frequency' (18:00 - 24h) so it waited until 18:30, and the next day waited until 19:00, etc.