### PR TITLE
fix quiz load message wrong date formatting

### DIFF
--- a/bot/src/discord_commands/quiz.js
+++ b/bot/src/discord_commands/quiz.js
@@ -409,7 +409,8 @@ function convertUserFacingSaveIdToDatabaseFacing(saveId) {
 
 function getTimeString(timestamp) {
   const date = new Date(timestamp);
-  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()} ${date.getHours()}:${date.getMinutes()}`;
+  const minutes = date.getMinutes();
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()} ${date.getHours()}:${minutes < 10 ? '0' + minutes : minutes}`;
 }
 
 function sendSaveMementos(msg, currentSaveMementos, recyclingBinMementos, extraContent) {


### PR DESCRIPTION
`getTimeString()` would return something like `"19/2/2021 7:3"` instead of `"19/2/2021 7:03"`.

It might be better to use JS's built-in date formatter instead of manual string templates.

![image](https://user-images.githubusercontent.com/35223375/108482702-66e34f80-72cc-11eb-9c57-625e27d7eb7f.png)
