### PR TITLE
change handling on disallowed small letters

### DIFF
--- a/node-common/shiritori/japanese_game_strategy.js
+++ b/node-common/shiritori/japanese_game_strategy.js
@@ -24,6 +24,8 @@ const largeHiraganaForSmallHiragana = {
   ぉ: 'お',
 };
 
+const noStartSmallHiragana = ['ぁ', 'ぉ', 'ぅ', 'ぇ', 'ぃ'];
+
 function getNextWordMustStartWith(settings, currentWordReading) {
   const finalCharacter = currentWordReading[currentWordReading.length - 1];
   let secondLastCharacter = undefined;
@@ -52,8 +54,13 @@ function getNextWordMustStartWith(settings, currentWordReading) {
     );
   }
 
+  // For words like ソファ, we should fall back to the head to avoid cases where nothing can be played.
+  if(!settings.smallLetters && largeHiraganaForSmallHiragana[finalCharacter] && noStartSmallHiragana.includes(finalCharacter)) {
+      return getNextWordMustStartWith(settings, wordHead);
+  }
+
   if(largeHiraganaForSmallHiragana[finalCharacter]) {
-    prevLetter = currentWordReading.substring(currentWordReading.length - 2, currentWordReading.length - 1);
+    prevLetter = currentWordReading[currentWordReading.length - 2];
     let accept = [];
 
     // We want to accept じゃ after くちぢゃ.
@@ -82,6 +89,8 @@ function getNextWordMustStartWith(settings, currentWordReading) {
     return ['お', 'を'];
   } else if (finalCharacter === 'っ') {
     return ['つ', 'っ'];
+  } else if (finalCharacter === 'ゔ') {
+    return ['ゔ', 'う'];
   }
 
   return [finalCharacter];


### PR DESCRIPTION
If something like ソファ is played, since words don't start with ふぁ, it is sensible to allow ふ instead, and if small letters are off, only ふ.

Perhaps, for ティ it would be better to accept ち than て, but that should be its own PR. The main issue is that it's not super clear what to do with end sounds like ふぇ、くぉ、うぃ etc.

This PR also handles ゔ because now words that end with ゔぇ exist, like ミクヴェ.