### PR TITLE
Add `xn` Conversion for `ん`

### DIFF
--- a/bot/src/common/util/convert_to_hiragana.js
+++ b/bot/src/common/util/convert_to_hiragana.js
@@ -172,6 +172,7 @@ const hiraganaForRomaji = {
 
   wa: 'わ',
   wo: 'を',
+  xn: 'ん',
   nn: 'ん',
   n: 'ん',
   'n\'': 'ん',


### PR DESCRIPTION
Resolves #364 

Not tested yet - are there any tests for the romaji kana conversion? I couldn't find any relevant files.