### PR TITLE
Allow skipping the WaitAction

### DIFF
--- a/bot/src/common/quiz/manager.js
+++ b/bot/src/common/quiz/manager.js
@@ -591,6 +591,12 @@ class WaitAction extends Action {
       this.fulfill_();
     }
   }
+
+  skip() {
+    if (this.fulfill_) {
+      this.fulfill_(this.nextAction_);
+    }
+  }
 }
 
 class SaveAction extends Action {


### PR DESCRIPTION
This enables a study method where the the delay after unanswered question is set to a high value like 2 minutes, allowing the user some time for steps that could help with learning such as: writing by hand, looking up etymology, looking up kanji, etc. While preventing the user from having to wait when the user deems it unnecessary.