### PR TITLE
Add quick search functionality to quiz

### DIFF
--- a/bot/src/bot_settings.js
+++ b/bot/src/bot_settings.js
@@ -164,6 +164,16 @@ module.exports = [
         convertInternalValueToUserFacingValue: SettingsConverters.toString,
         validateInternalValue: SettingsValidators.createRangeValidator(0.1, 5),
       },
+      {
+        userFacingName: 'Quick Search enabled',
+        description: 'When enabled, quiz results will contain reaction emojis that you can click on to get kanji information or example sentences for the resulting word.',
+        allowedValuesDescription: 'Either **enabled** or **disabled**',
+        uniqueId: 'quiz/japanese/quick_search_enabled',
+        defaultUserFacingValue: 'Disabled',
+        convertUserFacingValueToInternalValue: SettingsConverters.createStringToBooleanConverter('enabled', 'disabled'),
+        convertInternalValueToUserFacingValue: SettingsConverters.createBooleanToStringConverter('Enabled', 'Disabled'),
+        validateInternalValue: SettingsValidators.isBoolean,
+      },
     ],
   },
   {

--- a/bot/src/common/quiz/manager.js
+++ b/bot/src/common/quiz/manager.js
@@ -274,6 +274,7 @@ class ShowAnswersAction extends Action {
       let answersForUser = scores.getCurrentQuestionsAnswersForUser();
       let pointsForAnswer = scores.getCurrentQuestionPointsForAnswer();
       let scoreLimit = scores.getScoreLimit();
+      const quickSearchEnabled = session.isQuickSearchEnabled()
 
       if (answerersInOrder.length > 0) {
         sessionReportManager.notifyAnswered(session.getLocationId(), currentCard, answerersInOrder);
@@ -285,6 +286,7 @@ class ShowAnswersAction extends Action {
           pointsForAnswer,
           scoresForUser,
           scoreLimit,
+          quickSearchEnabled,
           )).catch(err => {
             globals.logger.warn({
               event: 'ERROR OUTPUTTING SCOREBOARD',
@@ -363,9 +365,10 @@ class ShowWrongAnswerAction extends Action {
   do() {
     let session = this.getSession_();
     let currentCard = session.getCurrentCard();
+    const quickSearchEnabled = session.isQuickSearchEnabled()
     sessionReportManager.notifyAnswered(session.getLocationId(), currentCard, []);
     session.markCurrentCardUnanswered();
-    return Promise.resolve(session.getMessageSender().showWrongAnswer(currentCard, this.skipped_, this.hardcore_)).catch(err => {
+    return Promise.resolve(session.getMessageSender().showWrongAnswer(currentCard, this.skipped_, this.hardcore_, quickSearchEnabled)).catch(err => {
       let question = currentCard.question;
       globals.logger.warn({
         event: 'FAILED TO SHOW TIMEOUT MESSAGE',

--- a/bot/src/common/quiz/session.js
+++ b/bot/src/common/quiz/session.js
@@ -170,6 +170,10 @@ class SessionInformation {
     return this.noRace_;
   }
 
+  isQuickSearchEnabled() {
+    return this.settings_.serverSettings.quickSearchEnabled;
+  }
+
   createSaveData() {
     return {
       deckCollectionSaveData: this.deckCollection_.createSaveData(),

--- a/bot/src/common/yourei_search.js
+++ b/bot/src/common/yourei_search.js
@@ -165,6 +165,24 @@ async function createNavigationForExamples(keyword, msg) {
   return PaginatedMessage.sendAsMessageReply(msg, chapters, { id: interactiveMessageId });
 }
 
+async function sendExamplesAsStandaloneMessage(keyword, ownerId, channel) {
+  const searchResults = await scrapeWebPage(keyword);
+
+  if (searchResults.data.sentences.length === 0) {
+    return throwPublicErrorInfo('用例.jp', `I didn't find any results for **${keyword}**.`, 'No results');
+  }
+
+  const chapters = [
+    { title: 'Sentences', pages: createNavigationChapterForSentences(searchResults, false) },
+    { title: 'Full Context', pages: createNavigationChapterForSentences(searchResults, true) },
+    { title: 'Usage', pages: createNavigationChapterForUsage(searchResults) },
+  ];
+
+  const interactiveMessageId = `yourei_"${keyword}"`;
+  return PaginatedMessage.send(channel, ownerId, chapters, { id: interactiveMessageId });
+}
+
 module.exports = {
   createNavigationForExamples,
+  sendExamplesAsStandaloneMessage
 };


### PR DESCRIPTION
This pr adds what I call "quick search" functionality to the tests.

It is enabled by going to `k!settings` -> 3: quiz -> 13, disabled by default.

When enabled for a user who starts a quiz, the response to answers (both correct and incorrect) will have 3 buttons: 
1. Look Up Kanji
2. Jisho Examples
3. Yourei Examples 

Clicking on these buttons will do the same thing as running `k!kanji`, `k!examples`, or `k!yourei` respectively for the question text.

<img width="556" alt="Screenshot 5785-09-14 at 22 57 53" src="https://github.com/user-attachments/assets/c20d40fc-1353-4969-9771-a9a615a7881f" />

This is the result of the discussion in https://github.com/mistval/kotoba/discussions/399.